### PR TITLE
build(rokid): CXR-M 1.0.4 -> 1.2.2 (16 KB page alignment)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -45,11 +45,6 @@ updates:
       # artifact form.
       - dependency-name: "com.vanniktech.maven.publish"
       - dependency-name: "com.vanniktech:gradle-maven-publish-plugin"
-      # CXR-M 1.2.2 breaks the device-rokid compile and buys nothing we need
-      # (see issue #9's SDK survey). The 1.0.4 adapter is hardware-validated;
-      # migrate deliberately alongside a Rokid hardware session (#29).
-      - dependency-name: "com.rokid.cxr:client-m"
-
   - package-ecosystem: "pip"
     directory: "/tools"
     schedule:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 - Added `GlassesEvent.LongPress` and `DeviceCapabilities.supportsLongPressEvents`, with Even G1, INMO Air3, and Simulator event support plus generated-app simulator buttons for hardware-free tap and long-press testing.
 
+### Changed
+
+- Rokid Android support now targets CXR-M 1.2.2, including the updated audio, Bluetooth, and Wi-Fi callback surfaces and the SDK's 16 KB-aligned native libraries.
+
 ## [0.2.0] - 2026-07-07
 
 ### Added

--- a/devices/device-rokid/build.gradle.kts
+++ b/devices/device-rokid/build.gradle.kts
@@ -12,7 +12,7 @@ dependencies {
     implementation(project(":core-android"))
 
     // Rokid CXR-M SDK
-    api("com.rokid.cxr:client-m:1.0.4") {
+    api("com.rokid.cxr:client-m:1.2.2") {
         // Avoid pulling the sources artifact transitively; keeps dependency graph smaller.
         exclude(group = "com.rokid.cxr", module = "client-m-sources")
     }

--- a/devices/device-rokid/src/main/java/com/xgglass/device/rokid/RokidGlassesClient.kt
+++ b/devices/device-rokid/src/main/java/com/xgglass/device/rokid/RokidGlassesClient.kt
@@ -66,7 +66,7 @@ import kotlin.coroutines.resumeWithException
  *
  * Notes:
  * - This SDK does NOT request runtime permissions; the host app must handle permissions.
- * - CXR-M v1.0.4 requires an SN authorization file (`.lc`) + developer `clientSecret` to connect.
+ * - CXR-M v1.2.2 requires an SN authorization file (`.lc`) + developer `clientSecret` to connect.
  */
 class RokidGlassesClient(
     private val activity: AppCompatActivity,
@@ -284,13 +284,34 @@ class RokidGlassesClient(
             val running = AtomicBoolean(true)
             val seq = AtomicLong(0)
             val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+            fun finishStream() {
+                if (!running.compareAndSet(true, false)) return
+                scope.cancel()
+                activeMic = null
+                shared.tryEmit(
+                    AudioChunk(
+                        bytes = ByteArray(0),
+                        format = fmt,
+                        sequence = seq.incrementAndGet(),
+                        endOfStream = true,
+                    )
+                )
+            }
 
             val listener = object : AudioStreamListener {
-                override fun onStartAudioStream(codecType: Int, streamType: String?) {
-                    // no-op
+                override fun onStartAudioStream(
+                    streamId: Int,
+                    codecType: Int,
+                    modeOrChannels: Int,
+                    streamType: String?
+                ) {
+                    emitLog(
+                        "Rokid: audio stream started id=$streamId codec=$codecType " +
+                            "modeOrChannels=$modeOrChannels stream=$streamType"
+                    )
                 }
 
-                override fun onAudioStream(data: ByteArray?, offset: Int, length: Int) {
+                override fun onAudioStream(streamId: Int, data: ByteArray?, offset: Int, length: Int) {
                     if (!running.get()) return
                     if (data == null) return
                     if (length <= 0) return
@@ -306,12 +327,28 @@ class RokidGlassesClient(
                         )
                     )
                 }
+
+                override fun onAudioStreamFinish(streamId: Int) {
+                    emitLog("Rokid: audio stream finished id=$streamId")
+                    finishStream()
+                }
             }
 
             // Register listener first to avoid losing the first chunks.
             CxrApi.getInstance().setAudioStreamListener(listener)
 
-            val st = CxrApi.getInstance().openAudioRecord(codecType, streamType)
+            // CXR-M 1.2.x replaces openAudioRecord(codec, cmd) with explicit
+            // (codec, mode, intent, denoiseMode). Decompiled 1.2.2 bytecode
+            // confirms denoiseMode=2 is the SDK default; no sample-rate or
+            // channel-count parameter is exposed on the microphone capture API.
+            // Keep the added mode value centralized until the compatibility
+            // capture mode can be revalidated on Rokid hardware.
+            val st = CxrApi.getInstance().openAudioRecord(
+                codecType,
+                ROKID_AUDIO_RECORD_MODE_COMPAT,
+                streamType,
+                ROKID_AUDIO_DENOISE_MODE_DEFAULT,
+            )
             if (st == ValueUtil.CxrStatus.REQUEST_FAILED) {
                 CxrApi.getInstance().setAudioStreamListener(null)
                 return Result.failure(GlassesError.Transport("Rokid openAudioRecord REQUEST_FAILED"))
@@ -326,23 +363,14 @@ class RokidGlassesClient(
                 override val audio: Flow<AudioChunk> = shared
 
                 override suspend fun stop() {
-                    if (!running.compareAndSet(true, false)) return
+                    if (!running.get()) return
                     try {
                         CxrApi.getInstance().closeAudioRecord(streamType)
                     } catch (_: Exception) {}
                     try {
                         CxrApi.getInstance().setAudioStreamListener(null)
                     } catch (_: Exception) {}
-                    scope.cancel()
-                    activeMic = null
-                    shared.tryEmit(
-                        AudioChunk(
-                            bytes = ByteArray(0),
-                            format = fmt,
-                            sequence = seq.incrementAndGet(),
-                            endOfStream = true,
-                        )
-                    )
+                    finishStream()
                 }
             }
 
@@ -413,6 +441,10 @@ class RokidGlassesClient(
                         completed = true
                         cont.resumeWithException(GlassesError.Transport("Rokid initWifiP2P failed: $errorCode"))
                     }
+                }
+
+                override fun onP2pDeviceAvailable(name: String?, address: String?, info: String?) {
+                    emitLog("Rokid: Wi‑Fi P2P device available name=$name address=$address info=$info")
                 }
             })
 
@@ -564,21 +596,24 @@ class RokidGlassesClient(
                 ) {
                     if (!socketUuid.isNullOrBlank() && !macAddress.isNullOrBlank()) {
                         if (done.compareAndSet(false, true)) {
-                        cont.resume(socketUuid to macAddress)
+                            cont.resume(socketUuid to macAddress)
                         }
                     } else {
                         if (done.compareAndSet(false, true)) {
-                        cont.resumeWithException(GlassesError.Transport("onConnectionInfo missing uuid/mac"))
+                            cont.resumeWithException(GlassesError.Transport("onConnectionInfo missing uuid/mac"))
                         }
                     }
                 }
 
                 override fun onConnected() = Unit
+                override fun onInActiveConnected(socketUuid: String?, macAddress: String?) {
+                    emitLog("Rokid: inactive Bluetooth connection available uuid=$socketUuid mac=$macAddress")
+                }
                 override fun onDisconnected() = Unit
 
                 override fun onFailed(errorCode: ValueUtil.CxrBluetoothErrorCode?) {
                     if (done.compareAndSet(false, true)) {
-                    cont.resumeWithException(GlassesError.Transport("initBluetooth failed: $errorCode"))
+                        cont.resumeWithException(GlassesError.Transport("initBluetooth failed: $errorCode"))
                     }
                 }
             })
@@ -601,20 +636,24 @@ class RokidGlassesClient(
 
                 override fun onConnected() {
                     if (done.compareAndSet(false, true)) {
-                    cont.resume(Unit)
+                        cont.resume(Unit)
                     }
+                }
+
+                override fun onInActiveConnected(socketUuid: String?, macAddress: String?) {
+                    emitLog("Rokid: inactive Bluetooth connection available uuid=$socketUuid mac=$macAddress")
                 }
 
                 override fun onDisconnected() {
                     if (done.compareAndSet(false, true)) {
-                    cont.resumeWithException(GlassesError.Transport("connectBluetooth disconnected"))
+                        cont.resumeWithException(GlassesError.Transport("connectBluetooth disconnected"))
                     }
                 }
 
                 override fun onFailed(errorCode: ValueUtil.CxrBluetoothErrorCode?) {
                     if (done.compareAndSet(false, true)) {
-                    cont.resumeWithException(GlassesError.Transport("connectBluetooth failed: $errorCode"))
-                }
+                        cont.resumeWithException(GlassesError.Transport("connectBluetooth failed: $errorCode"))
+                    }
                 }
             }, snLc, clientSecret)
         }
@@ -623,7 +662,7 @@ class RokidGlassesClient(
     private fun requireAuthorization(): Pair<ByteArray, String> {
         val auth = options.authorization
             ?: throw GlassesError.Transport(
-                "Rokid authorization missing. CXR-M v1.0.4 requires SN authorization file (.lc) bytes + clientSecret. " +
+                "Rokid authorization missing. CXR-M v1.2.2 requires SN authorization file (.lc) bytes + clientSecret. " +
                     "Provide them via RokidGlassesClient.RokidOptions(authorization = RokidAuthorization(...))."
             )
         if (auth.snLc.isEmpty()) {
@@ -659,7 +698,7 @@ class RokidGlassesClient(
     )
 
     /**
-     * CXR-M v1.0.4 Bluetooth connect requires:
+     * CXR-M v1.2.2 Bluetooth connect requires:
      * - `snLc`: SN authorization file (`.lc`) bound to the device SN (downloaded from Rokid console)
      * - `clientSecret`: developer credential (will be normalized by removing `-`)
      *
@@ -686,6 +725,8 @@ class RokidGlassesClient(
 
     private companion object {
         const val ROKID_SERVICE_UUID = "00009100-0000-1000-8000-00805f9b34fb"
+        const val ROKID_AUDIO_RECORD_MODE_COMPAT = 1
+        const val ROKID_AUDIO_DENOISE_MODE_DEFAULT = 2
 
         const val PREFS_BT = "xgglass_rokid_bt_reconnect"
         const val PREF_KEY_SOCKET_UUID = "socket_uuid"

--- a/devices/device-rokid/src/main/java/com/xgglass/device/rokid/RokidGlassesClient.kt
+++ b/devices/device-rokid/src/main/java/com/xgglass/device/rokid/RokidGlassesClient.kt
@@ -40,6 +40,7 @@ import com.xgglass.core.PhotoQuality
 import com.xgglass.core.PlayAudioOptions
 import com.xgglass.core.android.playPcmViaAudioTrack
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
@@ -52,6 +53,7 @@ import kotlinx.coroutines.withTimeout
 import java.io.File
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicLong
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
@@ -284,8 +286,12 @@ class RokidGlassesClient(
             val running = AtomicBoolean(true)
             val seq = AtomicLong(0)
             val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
-            fun finishStream() {
-                if (!running.compareAndSet(true, false)) return
+            val expectedStreamId = AtomicInteger(ROKID_AUDIO_STREAM_ID_UNSET)
+            val unexpectedStreamIdEvents = AtomicInteger(0)
+            val nullAudioFrameDrops = AtomicInteger(0)
+            val invalidAudioFrameDrops = AtomicInteger(0)
+
+            fun finishStreamAfterGate() {
                 scope.cancel()
                 activeMic = null
                 shared.tryEmit(
@@ -298,6 +304,29 @@ class RokidGlassesClient(
                 )
             }
 
+            fun finishStream() {
+                if (!running.compareAndSet(true, false)) return
+                finishStreamAfterGate()
+            }
+
+            fun warnUnexpectedStreamId(eventName: String, streamId: Int, expected: Int) {
+                val count = unexpectedStreamIdEvents.incrementAndGet()
+                if (shouldRateLimitLog(count)) {
+                    val expectedText = if (expected == ROKID_AUDIO_STREAM_ID_UNSET) "unset" else expected.toString()
+                    emitWarn(
+                        "Rokid: ignored $eventName for unexpected audio stream id=$streamId " +
+                            "expected=$expectedText; count=$count"
+                    )
+                }
+            }
+
+            fun isExpectedStreamId(eventName: String, streamId: Int): Boolean {
+                val expected = expectedStreamId.get()
+                if (expected == streamId) return true
+                warnUnexpectedStreamId(eventName, streamId, expected)
+                return false
+            }
+
             val listener = object : AudioStreamListener {
                 override fun onStartAudioStream(
                     streamId: Int,
@@ -305,6 +334,18 @@ class RokidGlassesClient(
                     modeOrChannels: Int,
                     streamType: String?
                 ) {
+                    val previous = expectedStreamId.get()
+                    if (previous == ROKID_AUDIO_STREAM_ID_UNSET) {
+                        expectedStreamId.compareAndSet(ROKID_AUDIO_STREAM_ID_UNSET, streamId)
+                    } else if (previous != streamId) {
+                        warnUnexpectedStreamId("audio stream start", streamId, previous)
+                    }
+
+                    // The 1.2.2 Java listener bytecode exposes this third int
+                    // only by position. Native strings around StartAudioStream
+                    // mention codec/originCodec/channels; the record API still
+                    // has no sample-rate/channel-count parameters, so keep the
+                    // public AudioFormat sampleRateHz/channelCount unknown.
                     emitLog(
                         "Rokid: audio stream started id=$streamId codec=$codecType " +
                             "modeOrChannels=$modeOrChannels stream=$streamType"
@@ -312,12 +353,40 @@ class RokidGlassesClient(
                 }
 
                 override fun onAudioStream(streamId: Int, data: ByteArray?, offset: Int, length: Int) {
+                    if (!isExpectedStreamId("audio stream frame", streamId)) return
                     if (!running.get()) return
-                    if (data == null) return
-                    if (length <= 0) return
+                    if (data == null) {
+                        val count = nullAudioFrameDrops.incrementAndGet()
+                        if (shouldRateLimitLog(count)) {
+                            emitWarn(
+                                "Rokid: dropped null audio frame streamId=$streamId " +
+                                    "offset=$offset length=$length; count=$count"
+                            )
+                        }
+                        return
+                    }
+                    if (length <= 0) {
+                        val count = invalidAudioFrameDrops.incrementAndGet()
+                        if (shouldRateLimitLog(count)) {
+                            emitWarn(
+                                "Rokid: dropped invalid audio frame streamId=$streamId " +
+                                    "offset=$offset length=$length dataSize=${data.size}; count=$count"
+                            )
+                        }
+                        return
+                    }
                     val start = offset.coerceAtLeast(0)
                     val end = (offset + length).coerceAtMost(data.size)
-                    if (end <= start) return
+                    if (end <= start) {
+                        val count = invalidAudioFrameDrops.incrementAndGet()
+                        if (shouldRateLimitLog(count)) {
+                            emitWarn(
+                                "Rokid: dropped invalid audio frame streamId=$streamId " +
+                                    "offset=$offset length=$length dataSize=${data.size}; count=$count"
+                            )
+                        }
+                        return
+                    }
                     val bytes = data.copyOfRange(start, end)
                     shared.tryEmit(
                         AudioChunk(
@@ -329,6 +398,7 @@ class RokidGlassesClient(
                 }
 
                 override fun onAudioStreamFinish(streamId: Int) {
+                    if (!isExpectedStreamId("audio stream finish", streamId)) return
                     emitLog("Rokid: audio stream finished id=$streamId")
                     finishStream()
                 }
@@ -363,14 +433,14 @@ class RokidGlassesClient(
                 override val audio: Flow<AudioChunk> = shared
 
                 override suspend fun stop() {
-                    if (!running.get()) return
+                    if (!running.compareAndSet(true, false)) return
                     try {
                         CxrApi.getInstance().closeAudioRecord(streamType)
                     } catch (_: Exception) {}
                     try {
                         CxrApi.getInstance().setAudioStreamListener(null)
                     } catch (_: Exception) {}
-                    finishStream()
+                    finishStreamAfterGate()
                 }
             }
 
@@ -396,6 +466,7 @@ class RokidGlassesClient(
                 btReady = true
                 return
             } catch (e: Exception) {
+                if (e is CancellationException) throw e
                 // Common in practice: cached reconnect info becomes stale after re-pair/reset/firmware changes.
                 // Fall back to scan+init flow automatically.
                 emitWarn("Rokid: BT reconnect failed, falling back to scan/init: ${e.message}")
@@ -607,7 +678,11 @@ class RokidGlassesClient(
 
                 override fun onConnected() = Unit
                 override fun onInActiveConnected(socketUuid: String?, macAddress: String?) {
-                    emitLog("Rokid: inactive Bluetooth connection available uuid=$socketUuid mac=$macAddress")
+                    emitWarn(
+                        "Rokid: vendor reported inactive Bluetooth connection uuid=$socketUuid mac=$macAddress; " +
+                            "adapter is intentionally not resolving connect from this callback. If connect later " +
+                            "times out, vendor resolved via inactive-connected; report on PR 66."
+                    )
                 }
                 override fun onDisconnected() = Unit
 
@@ -641,7 +716,11 @@ class RokidGlassesClient(
                 }
 
                 override fun onInActiveConnected(socketUuid: String?, macAddress: String?) {
-                    emitLog("Rokid: inactive Bluetooth connection available uuid=$socketUuid mac=$macAddress")
+                    emitWarn(
+                        "Rokid: vendor reported inactive Bluetooth connection uuid=$socketUuid mac=$macAddress; " +
+                            "adapter is intentionally not resolving connect from this callback. If connect later " +
+                            "times out, vendor resolved via inactive-connected; report on PR 66."
+                    )
                 }
 
                 override fun onDisconnected() {
@@ -689,6 +768,9 @@ class RokidGlassesClient(
             .apply()
     }
 
+    private fun shouldRateLimitLog(count: Int): Boolean =
+        count == 1 || count % RATE_LIMIT_EVERY == 0
+
     data class RokidOptions(
         val connectTimeoutMs: Long = 30_000,
         val defaultWidth: Int = 2400,
@@ -727,6 +809,8 @@ class RokidGlassesClient(
         const val ROKID_SERVICE_UUID = "00009100-0000-1000-8000-00805f9b34fb"
         const val ROKID_AUDIO_RECORD_MODE_COMPAT = 1
         const val ROKID_AUDIO_DENOISE_MODE_DEFAULT = 2
+        const val ROKID_AUDIO_STREAM_ID_UNSET = Int.MIN_VALUE
+        const val RATE_LIMIT_EVERY = 50
 
         const val PREFS_BT = "xgglass_rokid_bt_reconnect"
         const val PREF_KEY_SOCKET_UUID = "socket_uuid"


### PR DESCRIPTION
Migrates the Rokid adapter to CXR-M 1.2.2, primarily for the **16 KB native-library alignment** that Play-distributed consumer apps need (targetSdk 35+ requirement since 2025-11) — verified at the AAR and packaged-APK level (`PT_LOAD p_align=0x4000`).

Adapts the enumerated 1.2.2 breaking surface (audio listener signatures + `onAudioStreamFinish` → mic end-of-stream, `openAudioRecord` 4-arg overload with researched `mode`/`denoiseMode` compat values, two new diagnostic-only callbacks). Compile matrix, publishToMavenLocal, and a `--devices rokid` generated app are green.

**Draft until a Rokid hardware smoke confirms**: audio capture semantics under `mode=1, denoiseMode=2` (16 kHz mono as before), `onAudioStreamFinish` timing, and the inactive-connect flow. ~15 minutes with real glasses — see #63.

🤖 Generated with [Claude Code](https://claude.com/claude-code)